### PR TITLE
Refactor garmin maps generator

### DIFF
--- a/garmin/build.sh
+++ b/garmin/build.sh
@@ -1,12 +1,17 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
 
 TEMP_DIR=temp
 PBF_FILE=$1
 PBF_FILE_RU=/var/www/maps/pbf/belarus-ru.osm.pbf
-#PBF_FILE=~/belarus-latest-internal.osm.pbf
-#PBF_FILE=../in/belarus-latest.osm.pbf
 STYLES=styles
 BOUNDS=bounds-latest.zip
+#MKGMAP=mkgmap
+MKGMAP="java -jar mkgmap/mkgmap.jar"
+#SPLITTER=mkgmap-splitter
+SPLITTER="java -jar split/splitter.jar"
+OUT_DIR=out
 
 if [[ -n "$PBF_FILE"  ]]
 then
@@ -35,364 +40,67 @@ echo "STRANGER_STYLE_FILE = $STRANGER_STYLE_FILE "
 echo "TEMPLATE_ARGS = $TEMPLATE_ARGS "
 echo "STRANGER_TYP = $STRANGER_TYP "
 echo "DATE = $DATE"
+echo "OUT_DIR = $OUT_DIR"
 
-java -jar split/splitter.jar \
-    --max-nodes=1200000 \
-    --keep-complete=true \
-    --output=pbf \
-    --output-dir=$TEMP_DIR \
-    $PBF_FILE
-
-
+mkdir -p $OUT_DIR
 
 COUNTRY_NAME=Belarus
-COUNTRY_ABBR=BY
+COUNTRY_CODE=BY
 
-FAMILY_ID=5050
-MAPNAME=80808080
-PRODUCT_ID=1
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_generic.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-f 5050 \
+	-n "OpenStreetMap.by generic" \
+	-e "OpenStreetMap.by" \
+	-d "OSM default mkgmap style" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
-java -jar mkgmap/mkgmap.jar \
-    --route --add-pois-to-areas \
-    --index  \
-    --bounds=$BOUNDS \
-    --gmapsupp \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --link-pois-to-ways \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR  \
-    --description="Belarus_general, v.$DATE" \
-    --output-dir=$TEMP_DIR \
-    -c $TEMPLATE_ARGS
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_stranger.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-s styles/my_stranger -t styles/my_stranger.typ \
+	-f 5052 \
+	-n "OpenStreetMap + ST-GIS by Maks Vasilev" \
+	-e "OpenStreetMap.by" \
+	-y "OpenStreetMap CC-BY-SA 2.0, ST-GIS CC-BY-SA 3.0, ST-GIS, Maks Vasilev" \
+	-d "Belarus_velo100, v.$DATE" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
-
-echo "[INFO] Move result files $NAME"
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_general.img
-
-
-FAMILY_ID=5051
-MAPNAME=80818081
-PRODUCT_ID=2
-
-# java -jar mkgmap/mkgmap.jar \
-#     --verbose \
-#     --output-dir=$TEMP_DIR \
-#     --gmapsupp \
-#     --tdbfile \
-#     --series-name="OpenStreetMap.by" \
-#     --family-name="OpenStreetMap.by" \
-#     --description="Belarus_routes-bicycle, v.$DATE" \
-#     --country-name=$COUNTRY_NAME \
-#     --country-abbr=$COUNTRY_ABBR \
-#     --code-page=1251 \
-#     --lower-case \
-#     --name-tag-list=name,name:ru,name:be,int_name \
-#     --style=routes-bicycle \
-#     --remove-short-arcs \
-#     --drive-on=right \
-#     --check-roundabouts \
-#     --mapname=$MAPNAME \
-#     --family-id=$FAMILY_ID \
-#     --product-id=$PRODUCT_ID \
-#     --make-poi-index \
-#     --index \
-#     --poi-address \
-#     --route \
-#     --draw-priority=31 \
-#     --bounds=$BOUNDS \
-#     --housenumbers \
-#     --add-pois-to-areas \
-#     -c $TEMPLATE_ARGS  $GENERIC_TYP
-    
-# java -jar mkgmap/mkgmap.jar \
-#     --route --add-pois-to-areas \
-#     --bounds=$BOUNDS \
-#     --index  \
-#     --gmapsupp \
-#     --name-tag-list=name,name:ru,name:be,int_name \
-#     --mapname=$MAPNAME \
-#     --family-id=$FAMILY_ID \
-#     --link-pois-to-ways \
-#     --style=routes-bicycle \
-#     --country-name=$COUNTRY_NAME \
-#     --country-abbr=$COUNTRY_ABBR  \
-#     --description="Belarus_bicycle, v.$DATE" \
-#     --output-dir=$TEMP_DIR \
-#     -c $TEMPLATE_ARGS
-
-# echo "[INFO] Move result files $NAME"
-# mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_routes_bicycle.img
-
-
-FAMILY_ID=5052
-MAPNAME=80828082
-PRODUCT_ID=3
-
-java -jar mkgmap/mkgmap.jar \
-    --verbose \
-    --output-dir=$TEMP_DIR \
-    --gmapsupp \
-    --tdbfile \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap + ST-GIS by Maks Vasilev" \
-    --description="Belarus_velo100, v.$DATE" \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR \
-    --copyright-message="OpenStreetMap CC-BY-SA 2.0, ST-GIS CC-BY-SA 3.0, ST-GIS, Maks Vasilev" \
-    --code-page=1251 \
-    --lower-case \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --style-file=$STRANGER_STYLE_FILE \
-    --remove-short-arcs \
-    --drive-on=right \
-    --check-roundabouts \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --make-poi-index \
-    --index \
-    --poi-address \
-    --route \
-    --draw-priority=31 \
-    --bounds=$BOUNDS \
-    --housenumbers \
-    --add-pois-to-areas \
-    -c $TEMPLATE_ARGS  $STRANGER_TYP
-
-echo "[INFO] Move result files $NAME"
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_stranger.img
-
-
-FAMILY_ID=5053
-MAPNAME=80838083
-PRODUCT_ID=4
-
-java -jar mkgmap/mkgmap.jar \
-    --verbose \
-    --output-dir=$TEMP_DIR \
-    --gmapsupp \
-    --tdbfile \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --description="Belarus_generic_new, v.$DATE" \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR \
-    --code-page=1251 \
-    --lower-case \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --style-file=$GENERIC_STYLE_FILE \
-    --remove-short-arcs \
-    --drive-on=right \
-    --check-roundabouts \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --make-poi-index \
-    --index \
-    --poi-address \
-    --route \
-    --draw-priority=31 \
-    --bounds=$BOUNDS \
-    --housenumbers \
-    --add-pois-to-areas \
-    -c $TEMPLATE_ARGS  $GENERIC_TYP
-
-echo "[INFO] Move result files $NAME"
-
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_generic_new.img
-
-mv temp/"$NAME"* /var/www/maps/garmin/
-
-echo "[INFO] Delete temp files"
-rm -rf  $TEMP_DIR/*
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_generic_new.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-s styles/generic_new -t styles/generic_new.typ \
+	-f 5053 \
+	-n "OpenStreetMap generic, new" \
+	-e "OpenStreetMap.by" \
+	-d "Belarus_generic_new, v.$DATE" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
 
 PBF_FILE=$PBF_FILE_RU
-STYLES=styles
-BOUNDS=bounds-latest.zip
 
-TEMPLATE_ARGS="$TEMP_DIR/template.args"
-STRANGER_STYLE_FILE="$STYLES/my_stranger/"
-STRANGER_TYP="$STYLES/my_stranger.typ"
-GENERIC_STYLE_FILE="$STYLES/generic_new/"
-GENERIC_TYP="$STYLES/generic_new.typ"
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_generic_ru.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-f 5054 \
+	-n "OpenStreetMap.by generic (ru)" \
+	-e "OpenStreetMap.by" \
+	-d "OSM default mkgmap style, ru" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
-DATE=`date +%F`
-NAME="Belarus_map"
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_stranger_ru.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-s styles/my_stranger -t styles/my_stranger.typ \
+	-f 5055 \
+	-n "OpenStreetMap + ST-GIS by Maks Vasilev (ru)" \
+	-e "OpenStreetMap.by" \
+	-y "OpenStreetMap CC-BY-SA 2.0, ST-GIS CC-BY-SA 3.0, ST-GIS, Maks Vasilev" \
+	-d "Belarus_velo100, v.$DATE, ru" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
-echo "TEMP_DIR = $TEMP_DIR "
-echo "STYLES = $STYLES "
-echo "BOUNDS = $BOUNDS "
-echo "STRANGER_STYLE_FILE = $STRANGER_STYLE_FILE "
-echo "TEMPLATE_ARGS = $TEMPLATE_ARGS "
-echo "STRANGER_TYP = $STRANGER_TYP "
-echo "DATE = $DATE"
+./build_map.sh -i "$PBF_FILE" -o "$OUT_DIR/${NAME}_generic_new_ru.img" \
+	-m "$MKGMAP" -S "$SPLITTER" \
+	-s styles/generic_new -t styles/generic_new.typ \
+	-f 5056 \
+	-n "OpenStreetMap generic, new (ru)" \
+	-e "OpenStreetMap.by" \
+	-d "Belarus_generic_new, v.$DATE, ru" \
+	-c "$COUNTRY_NAME" -k $COUNTRY_CODE
 
-
-java -jar split/splitter.jar \
-    --max-nodes=1200000 \
-    --keep-complete=true \
-    --output=pbf \
-    --output-dir=$TEMP_DIR \
-    $PBF_FILE
-
-
-
-COUNTRY_NAME=Belarus
-COUNTRY_ABBR=BY
-
-FAMILY_ID=5050
-MAPNAME=80808080
-PRODUCT_ID=1
-
-java -jar mkgmap/mkgmap.jar \
-    --route --add-pois-to-areas \
-    --index  \
-    --bounds=$BOUNDS \
-    --gmapsupp \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --link-pois-to-ways \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR  \
-    --description="Belarus_general, v.$DATE" \
-    --output-dir=$TEMP_DIR \
-    -c $TEMPLATE_ARGS
-
-
-echo "[INFO] Move result files $NAME"
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_general_ru.img
-
-
-FAMILY_ID=5051
-MAPNAME=80818081
-PRODUCT_ID=2
-
-# java -jar mkgmap/mkgmap.jar \
-#     --verbose \
-#     --output-dir=$TEMP_DIR \
-#     --gmapsupp \
-#     --tdbfile \
-#     --series-name="OpenStreetMap.by" \
-#     --family-name="OpenStreetMap.by" \
-#     --description="Belarus_routes-bicycle, v.$DATE" \
-#     --country-name=$COUNTRY_NAME \
-#     --country-abbr=$COUNTRY_ABBR \
-#     --code-page=1251 \
-#     --lower-case \
-#     --name-tag-list=name,name:ru,name:be,int_name \
-#     --style=routes-bicycle \
-#     --remove-short-arcs \
-#     --drive-on=right \
-#     --check-roundabouts \
-#     --mapname=$MAPNAME \
-#     --family-id=$FAMILY_ID \
-#     --product-id=$PRODUCT_ID \
-#     --make-poi-index \
-#     --index \
-#     --poi-address \
-#     --route \
-#     --draw-priority=31 \
-#     --bounds=$BOUNDS \
-#     --housenumbers \
-#     --add-pois-to-areas \
-#     -c $TEMPLATE_ARGS  $GENERIC_TYP
-    
-
-# echo "[INFO] Move result files $NAME"
-# mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_routes_bicycle_ru.img
-
-
-FAMILY_ID=5052
-MAPNAME=80828082
-PRODUCT_ID=3
-
-java -jar mkgmap/mkgmap.jar \
-    --verbose \
-    --output-dir=$TEMP_DIR \
-    --gmapsupp \
-    --tdbfile \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap + ST-GIS by Maks Vasilev" \
-    --description="Belarus_velo100, v.$DATE" \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR \
-    --copyright-message="OpenStreetMap CC-BY-SA 2.0, ST-GIS CC-BY-SA 3.0, ST-GIS, Maks Vasilev" \
-    --code-page=1251 \
-    --lower-case \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --style-file=$STRANGER_STYLE_FILE \
-    --remove-short-arcs \
-    --drive-on=right \
-    --check-roundabouts \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --make-poi-index \
-    --index \
-    --poi-address \
-    --route \
-    --draw-priority=31 \
-    --bounds=$BOUNDS \
-    --housenumbers \
-    --add-pois-to-areas \
-    -c $TEMPLATE_ARGS  $STRANGER_TYP
-
-
-echo "[INFO] Move result files $NAME"
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_stranger_ru.img
-
-
-FAMILY_ID=5053
-MAPNAME=80838083
-PRODUCT_ID=4
-
-java -jar mkgmap/mkgmap.jar \
-    --verbose \
-    --output-dir=$TEMP_DIR \
-    --gmapsupp \
-    --tdbfile \
-    --series-name="OpenStreetMap.by" \
-    --family-name="OpenStreetMap.by" \
-    --description="Belarus_generic_new, v.$DATE" \
-    --country-name=$COUNTRY_NAME \
-    --country-abbr=$COUNTRY_ABBR \
-    --code-page=1251 \
-    --lower-case \
-    --name-tag-list=name,name:ru,name:be,int_name \
-    --style-file=$GENERIC_STYLE_FILE \
-    --remove-short-arcs \
-    --drive-on=right \
-    --check-roundabouts \
-    --mapname=$MAPNAME \
-    --family-id=$FAMILY_ID \
-    --product-id=$PRODUCT_ID \
-    --make-poi-index \
-    --index \
-    --poi-address \
-    --route \
-    --draw-priority=31 \
-    --bounds=$BOUNDS \
-    --housenumbers \
-    --add-pois-to-areas \
-    -c $TEMPLATE_ARGS  $GENERIC_TYP
-
-
-echo "[INFO] Move result files $NAME"
-mv $TEMP_DIR/gmapsupp.img $TEMP_DIR/"$NAME"_generic_new_ru.img
-
-mv temp/Belarus_map_* /var/www/maps/garmin/
-
-echo "[INFO] Delete temp files"
-rm -rf  $TEMP_DIR/*

--- a/garmin/build_map.sh
+++ b/garmin/build_map.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+TEMP_DIR=temp
+BOUNDS=bounds-latest.zip
+SEA=sea-latest.zip
+MKGMAP=mkgmap
+SPLITTER=mkgmap-splitter
+
+FAMILY_ID="6324" # mkgmap default
+PRODUCT_ID=1
+
+TEMPLATE_ARGS="$TEMP_DIR/template.args"
+MKGMAP_ARGS=""
+
+mkdir -p $TEMP_DIR
+rm -rf $TEMP_DIR/*
+
+usage() {
+	echo "Usage: $0 <options>" >&2
+	echo "Required args:" >&2
+	echo "  -i <input.pbf>	Input file" >&2
+	echo "  -o <output.img>	Output file" >&2
+	echo "  -" >&2
+	echo "  -" >&2
+	echo "  -" >&2
+	echo "  -" >&2
+
+	echo "Options:" >&2
+	echo "  -s <style>		Path to mkgmap style" >&2
+	echo "  -t <TYP file>		Path to TYP file" >&2
+	echo "  -c <country>		Country name" >&2
+	echo "  -k <country code>	Country code, 2-symbols" >&2
+	echo "  -d <description>	Map description" >&2
+	echo "  -y <copyright>	Copyright text" >&2
+	echo "  -f <family>		Map Family ID" >&2
+	echo "  -n <family name>	Family name" >&2
+	echo "  -e <series name>	Series name" >&2
+	echo "  -m <mkgmap>		Command to run mkgmap [default: mkgmap]" >&2
+	echo "  -S <splitter>		Command to run splitter [default: mkgmap-splitter]" >&2
+	echo "  -v			Verbose output" >&2
+
+	exit 1
+}
+
+while getopts "ho:i:f:s:t:c:k:y:n:e:m:S:d:" arg; do
+	case "${arg}" in
+		h)
+			usage ;;
+		i)
+			INPUT_FILE="${OPTARG}" ;;
+		o)
+			OUTPUT_FILE="${OPTARG}" ;;
+		f)
+			FAMILY_ID="${OPTARG}" ;;
+		s)
+			MKGMAP_ARGS="$MKGMAP_ARGS --style-file='${OPTARG}'" ;;
+		t)
+			TYP_FILE="${OPTARG}" ;;
+		c)
+			MKGMAP_ARGS="$MKGMAP_ARGS --country-name='${OPTARG}'" ;;
+		k)
+			MKGMAP_ARGS="$MKGMAP_ARGS --country-abbr='${OPTARG}'" ;;
+		y)
+			MKGMAP_ARGS="$MKGMAP_ARGS --copyright-message='${OPTARG}'" ;;
+		d)
+			MKGMAP_ARGS="$MKGMAP_ARGS --description='${OPTARG}'" ;;
+		n)
+			MKGMAP_ARGS="$MKGMAP_ARGS --family-name='${OPTARG}'" ;;
+		e)
+			MKGMAP_ARGS="$MKGMAP_ARGS --series-name='${OPTARG}'" ;;
+		v)
+			MKGMAP_ARGS="$MKGMAP_ARGS --verbose --report-roundabout-issues=all" ;;
+		m)
+			MKGMAP="${OPTARG}" ;;
+		S)
+			SPLITTER="${OPTARG}" ;;
+
+		*)
+			usage ;;
+	esac
+done
+
+if [ -z "$INPUT_FILE" ]; then
+	echo "Input file is not defined" >&2
+	usage
+fi
+
+if [ -z "$OUTPUT_FILE" ]; then
+	echo "Output file is not defined" >&2
+	usage
+fi
+
+echo "Input:		$INPUT_FILE"
+echo "Output file:	$OUTPUT_FILE"
+echo "TYP file:		$TYP_FILE"
+echo "Family:		$FAMILY_ID"
+echo "Additional options:	$MKGMAP_ARGS"
+
+set -e
+
+MAPNAME=${FAMILY_ID}0001
+
+echo "Run splitter for $INPUT_FILE..."
+$SPLITTER \
+    --precomp-sea="$SEA" \
+    --max-nodes=1200000 \
+    --keep-complete=true \
+    --output=pbf \
+    --output-dir="$TEMP_DIR" \
+    --mapid=$MAPNAME \
+    "$INPUT_FILE" > "$TEMP_DIR/splitter.log"
+
+echo "Run mkgmap..."
+eval $MKGMAP \
+    --output-dir="$TEMP_DIR" \
+    --gmapsupp \
+    --tdbfile \
+    --code-page=1251 \
+    --lower-case \
+    --name-tag-list=name,name:ru,name:be,int_name \
+    --remove-short-arcs \
+    --drive-on=right \
+    --mapname=$MAPNAME \
+    --family-id=$FAMILY_ID \
+    --product-id=$PRODUCT_ID \
+    --make-poi-index \
+    --index \
+    --poi-address \
+    --route \
+    --draw-priority=31 \
+    --bounds="$BOUNDS" \
+    --precomp-sea="$SEA" \
+    --housenumbers \
+    --add-pois-to-areas \
+    $MKGMAP_ARGS \
+    -c "$TEMPLATE_ARGS"  "$TYP_FILE"
+
+echo "Done, copying result to $OUTPUT_FILE"
+
+mv "$TEMP_DIR/gmapsupp.img" "$OUTPUT_FILE"
+rm -rf temp/*
+
+

--- a/garmin/prepare.sh
+++ b/garmin/prepare.sh
@@ -6,7 +6,7 @@ SPLITTER_VER=latest
 
 wget http://www.mkgmap.org.uk/download/mkgmap-$MKGMAP_VER.tar.gz
 
-rm --rf mkgmap split temp
+rm -rf mkgmap split temp
 mkdir mkgmap split temp
 
 tar -xf mkgmap-$MKGMAP_VER.tar.gz --directory mkgmap
@@ -23,6 +23,5 @@ rm -rf  split/splitter-*
 rm splitter-$SPLITTER_VER.tar.gz
 
 rm -rf bounds*
-# wget http://osm.thkukuk.de/data/bounds-latest.zip -o bounds-latest.zip
-curl http://osm.thkukuk.de/data/bounds-latest.zip --output bounds-latest.zip
-curl http://osm.thkukuk.de/data/sea-latest.zip --output sea-latest.zip
+curl https://www.thkukuk.de/osm/data/bounds-latest.zip --output bounds-latest.zip
+curl https://www.thkukuk.de/osm/data/sea-latest.zip --output sea-latest.zip

--- a/osmMapCreator.py
+++ b/osmMapCreator.py
@@ -112,6 +112,7 @@ garminDir = os.path.abspath('garmin')
 OAMCDir = os.path.join(osmandDir, 'OsmAndMapCreator')
 
 tempGarmin = os.path.join(garminDir, 'temp')
+tempOutGarmin = os.path.join(garminDir, 'out')
 tempOrganicmap = os.path.join(organicmapDir, 'map_build')
 tempSplit = os.path.join(currentDir, 'split')
 
@@ -122,7 +123,7 @@ outOsmAnd = os.path.join(outDir, 'osmand')
 outOrganicmaps = os.path.join(outDir, 'organicmap')
 outGarmin = os.path.join(outDir, 'garmin')
 
-tempDirs = [tempOrganicmap, tempGarmin, tempSplit]
+tempDirs = [tempOrganicmap, tempGarmin, tempOutGarmin, tempSplit]
 innerDirs = [polyDir, splitDir, organicmapDir, osmandDir, garminDir, OAMCDir, logsDir]
 outDirs = [outDir, outOsmAnd, outOrganicmaps, outGarmin]
 
@@ -344,7 +345,7 @@ def moveGarmin():
     log('move garmin map')
     try:
         name = 'Belarus_*.img'
-        path = tempGarmin + '/' + name
+        path = tempOutGarmin + '/' + name
         for file in glob.glob(path):
             shutil.move(file, outGarmin)
             garminCount = garminCount + 1


### PR DESCRIPTION
Isolate map generation commands in separated script, build_map.sh.

Fix invalid mapnames in resulted .img files: we cannot use one splitter output for all maps variants because resulted maps will conflict. Call splitter before every mkgmap. This increases build time but it is more reliable than editing of filenames and template.args with sed.

Fix some syntax errors and update URLs for precompiled sea and bounds poygons.

Closes: #1 